### PR TITLE
fix: Express 인증 미들웨어 에러 전파 로직 수정

### DIFF
--- a/src/core/middlewares/authMiddleware.ts
+++ b/src/core/middlewares/authMiddleware.ts
@@ -3,20 +3,22 @@ import { verifyAccessToken } from '#modules/auth/utils/tokenUtils';
 import ApiError from '#errors/ApiError';
 import { UserRole } from '@prisma/client';
 
-const authMiddleware: RequestHandler = (req, res, next) => {
-  const cookies = req.cookies as Record<string, string>;
-  const token = cookies['access_token'];
+const authMiddleware: RequestHandler = (req, _res, next) => {
+  try {
+    const cookies = req.cookies as Record<string, string>;
+    const token = cookies['access_token'];
+    if (!token) return next(new ApiError(401, '로그인이 필요합니다.'));
 
-  if (!token) throw new ApiError(401, '로그인이 필요합니다.');
+    const decoded = verifyAccessToken(token) as { id: string; role: UserRole };
+    req.user = {
+      id: decoded.id,
+      role: decoded.role,
+    };
 
-  const decoded = verifyAccessToken(token) as { id: string; role: UserRole };
-
-  req.user = {
-    id: decoded.id,
-    role: decoded.role,
-  };
-
-  next();
+    next();
+  } catch (err) {
+    next(err);
+  }
 };
 
 export default authMiddleware;

--- a/src/core/middlewares/requireRole.ts
+++ b/src/core/middlewares/requireRole.ts
@@ -2,12 +2,12 @@ import { UserRole } from '@prisma/client';
 import { NextFunction, Request, Response } from 'express';
 import ApiError from '#errors/ApiError';
 
-const requireRole = (allowedRole: UserRole[]) => {
+const requireRole = (allowedRoles: UserRole[]) => {
   return (req: Request, _res: Response, next: NextFunction) => {
-    if (!req.user) throw new ApiError(401, '로그인이 필요합니다');
+    if (!req.user) return next(new ApiError(401, '로그인이 필요합니다'));
 
     const userRole = req.user.role;
-    if (!allowedRole.includes(userRole)) throw new ApiError(403, '접근 권한이 없습니다');
+    if (!allowedRoles.includes(userRole)) return next(new ApiError(403, '접근 권한이 없습니다'));
 
     return next();
   };

--- a/src/modules/auth/utils/tokenUtils.ts
+++ b/src/modules/auth/utils/tokenUtils.ts
@@ -1,42 +1,65 @@
-import jwt from 'jsonwebtoken';
-import { ACCESS_TOKEN_SECRET, REFRESH_TOKEN_SECRET } from '#core/env';
+import jwt, { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
+import env from '#core/env';
 import type { DecodedToken, AuthHeaderDto } from '#modules/auth/dto/token.dto';
 import ApiError from '#errors/ApiError';
 import { UserRole } from '@prisma/client';
 
+/**
+ * Authorization 헤더에서 Bearer 토큰 추출
+ */
 export const extractToken = (authHeader: AuthHeaderDto): string => {
-  if (!authHeader.authorization.startsWith('Bearer ')) throw ApiError.unauthorized('토큰 형식이 올바르지 않습니다.');
+  if (!authHeader?.authorization?.startsWith('Bearer ')) throw ApiError.unauthorized('토큰 형식이 올바르지 않습니다.');
   return authHeader.authorization.slice(7);
 };
 
+/**
+ * Access Token 생성
+ */
 export const generateAccessToken = (user: { id: string; role: UserRole }): string => {
   try {
-    return jwt.sign({ id: user.id, role: user.role }, ACCESS_TOKEN_SECRET, { expiresIn: '1h' });
-  } catch (_err) {
-    throw new ApiError(500, '❌ Access Token 생성에 실패했습니다.');
+    return jwt.sign({ id: user.id, role: user.role }, env.ACCESS_TOKEN_SECRET, { expiresIn: '1h' });
+  } catch (err) {
+    throw new ApiError(500, '❌ Access Token 생성에 실패했습니다.', 'INTERNAL_ERROR', err);
   }
 };
 
+/**
+ * Access Token 검증
+ */
 export const verifyAccessToken = (token: string): DecodedToken => {
   try {
-    return jwt.verify(token, ACCESS_TOKEN_SECRET) as DecodedToken;
-  } catch {
-    throw new ApiError(401, '❌ Access Token이 유효하지 않습니다.');
+    return jwt.verify(token, env.ACCESS_TOKEN_SECRET) as DecodedToken;
+  } catch (err) {
+    if (err instanceof TokenExpiredError)
+      throw new ApiError(401, '❌ Access Token이 만료되었습니다.', 'UNAUTHORIZED', err);
+    if (err instanceof JsonWebTokenError)
+      throw new ApiError(401, '❌ Access Token이 유효하지 않습니다.', 'UNAUTHORIZED', err);
+    throw new ApiError(500, '❌ Access Token 검증 중 오류가 발생했습니다.', 'INTERNAL_ERROR', err);
   }
 };
 
+/**
+ * Refresh Token 생성
+ */
 export const generateRefreshToken = (user: { id: string }): string => {
   try {
-    return jwt.sign({ id: user.id }, REFRESH_TOKEN_SECRET, { expiresIn: '14d' });
-  } catch (_err) {
-    throw new ApiError(500, '❌ Refresh Token 생성에 실패했습니다.');
+    return jwt.sign({ id: user.id }, env.REFRESH_TOKEN_SECRET, { expiresIn: '14d' });
+  } catch (err) {
+    throw new ApiError(500, '❌ Refresh Token 생성에 실패했습니다.', 'INTERNAL_ERROR', err);
   }
 };
 
+/**
+ * Refresh Token 검증
+ */
 export const verifyRefreshToken = (token: string): DecodedToken => {
   try {
-    return jwt.verify(token, REFRESH_TOKEN_SECRET) as DecodedToken;
-  } catch {
-    throw new ApiError(403, '❌ Refresh Token이 유효하지 않습니다.');
+    return jwt.verify(token, env.REFRESH_TOKEN_SECRET) as DecodedToken;
+  } catch (err) {
+    if (err instanceof TokenExpiredError)
+      throw new ApiError(403, '❌ Refresh Token이 만료되었습니다.', 'FORBIDDEN', err);
+    if (err instanceof JsonWebTokenError)
+      throw new ApiError(403, '❌ Refresh Token이 유효하지 않습니다.', 'FORBIDDEN', err);
+    throw new ApiError(500, '❌ Refresh Token 검증 중 오류가 발생했습니다.', 'INTERNAL_ERROR', err);
   }
 };


### PR DESCRIPTION
## 주요 변경 사항
- `authMiddleware`, `tokenUtils` 및 `requireRole`에서 에러 전파를 `throw new ApiError()` 대신 `next(err)` 기반으로 수정했습니다.
  - 관련 테스트(`authMiddleware.test.ts`, `requireRole.test.ts`) 전부 통과 확인
    - 전역 에러 핸들링 체인 정상 작동 확인
    - 테스트 시 `401 / 403` 응답 정상 반환 확인
    - 해당 테스트는 별도로 PR할 예정
- `tokenUtils`에서 JWT 예외 타입(`TokenExpiredError`, `JsonWebTokenError`)별 처리를 추가했습니다.
  - 상태 코드(`UNAUTHORIZED`, `FORBIDDEN`, `INTERNAL_ERROR`) 지정

## 추가 변경 사항
- `authMiddleware`의 env import 방식을 named export → env 객체 기반으로 변경했습니다.
  - `env.ts` 변경에 따른 사이드 이펙트 정리
- `requireRole`가 배열 기반으로 동작하므로, 인자명을 `allowedRole` → `allowedRoles`로 변경했습니다.

## 참고 사항
- Express 미들웨어 내부에서는 `throw` 대신 `return next(new ApiError(...))`를 사용해 주세요.
- 하위 유틸(`tokenUtils`) 예외는 상위(`authMiddleware`)에서 `try/catch → next(err)`로 감싸야 전역 핸들러로 전달할 수 있습니다.

## 관련 이슈
#35 