### PR TITLE
docs(complaint): 민원 API 주석추가

### DIFF
--- a/src/modules/complaints/complaints.controller.ts
+++ b/src/modules/complaints/complaints.controller.ts
@@ -9,6 +9,12 @@ import { ComplaintListQuery } from './dto/querys.dto';
 import * as complaintService from './complaints.service';
 import { RESPONSE_MESSAGES } from '#constants/response.constant';
 
+/**
+ * 민원 생성 핸들러
+ * @description Validator에서 검증된 데이터를 Service로 전달하여 민원 생성
+ * @returns 201 Created - 생성 성공 메시지
+ * @throws ApiError - 권한 없음, 아파트 없음 등
+ */
 export const createComplaintHandler = async (_req: Request, res: Response, next: NextFunction) => {
   try {
     const data = res.locals.validatedBody as ComplaintCreateDto;
@@ -19,6 +25,14 @@ export const createComplaintHandler = async (_req: Request, res: Response, next:
   }
 };
 
+/**
+ * 민원 목록 조회 핸들러
+ * @description 사용자 권한에 따라 조회 가능한 민원 목록 반환
+ *   - USER: 본인이 작성한 민원만 조회
+ *   - ADMIN: 관리 아파트의 모든 민원 조회
+ * @returns 200 OK - 민원 목록 (페이지네이션 포함)
+ * @throws ApiError - 권한 없음
+ */
 export const getComplaintListHandler = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const userId = req.user.id;
@@ -31,6 +45,14 @@ export const getComplaintListHandler = async (req: Request, res: Response, next:
   }
 };
 
+/**
+ * 민원 상세 조회 핸들러
+ * @description 사용자 권한에 따라 민원 상세 정보 반환
+ *   - USER: 본인이 작성한 민원만 조회 가능
+ *   - ADMIN: 관리 아파트의 모든 민원 조회 가능
+ * @returns 200 OK - 민원 상세 정보
+ * @throws ApiError - 민원 없음, 조회 권한 없음
+ */
 export const getComplaintHandler = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const complaintId = req.params.complaintId;
@@ -43,6 +65,12 @@ export const getComplaintHandler = async (req: Request, res: Response, next: Nex
   }
 };
 
+/**
+ * 민원 수정 핸들러
+ * @description Validator에서 검증된 데이터를 Service로 전달하여 민원 수정
+ * @returns 200 OK - 수정된 민원 정보
+ * @throws ApiError - 민원 없음, 수정 권한 없음 (본인 민원만 수정 가능)
+ */
 export const patchComplaintHandler = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const complaintId = req.params.complaintId;
@@ -55,6 +83,12 @@ export const patchComplaintHandler = async (req: Request, res: Response, next: N
   }
 };
 
+/**
+ * 민원 상태 변경 핸들러
+ * @description ADMIN이 민원 상태를 변경 (접수 중, 처리 중, 완료, 반려)
+ * @returns 200 OK - 상태가 변경된 민원 정보
+ * @throws ApiError - 민원 없음, 권한 없음 (ADMIN 전용)
+ */
 export const patchComplaintStatusHandler = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const complaintId = req.params.complaintId;
@@ -66,6 +100,14 @@ export const patchComplaintStatusHandler = async (req: Request, res: Response, n
   }
 };
 
+/**
+ * 민원 삭제 핸들러
+ * @description Validator에서 검증된 데이터를 Service로 전달하여 민원 삭제
+ * @returns 200 OK - 삭제 성공 메시지
+ * @throws ApiError - 민원 없음, 삭제 권한 없음
+ *   - USER: 본인 민원만 삭제 가능
+ *   - ADMIN: 관리 아파트의 모든 민원 삭제 가능
+ */
 export const deleteComplaintHandler = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const complaintId = req.params.complaintId;

--- a/src/modules/complaints/complaints.repo.ts
+++ b/src/modules/complaints/complaints.repo.ts
@@ -8,6 +8,9 @@ import { BoardType, ComplaintStatus } from '@prisma/client';
 
 /**
  * 사용자 ID로 민원 게시판 ID 조회
+ * @description USER가 속한 아파트의 민원 게시판 ID를 조회합니다
+ * @param userId - 사용자 ID
+ * @returns 민원 게시판 ID (없으면 undefined)
  */
 export const getComplaintBoardIdByUserId = async (userId: string) => {
   const board = await prisma.board.findFirst({
@@ -31,6 +34,12 @@ export const getComplaintBoardIdByUserId = async (userId: string) => {
   return board?.id;
 };
 
+/**
+ * 관리자 ID로 민원 게시판 ID 조회
+ * @description ADMIN이 관리하는 아파트의 민원 게시판 ID를 조회합니다
+ * @param adminId - 관리자 ID
+ * @returns 민원 게시판 ID (없으면 undefined)
+ */
 export const getComplaintBoardIdByAdminId = async (adminId: string) => {
   const board = await prisma.board.findFirst({
     where: {
@@ -50,6 +59,9 @@ export const getComplaintBoardIdByAdminId = async (adminId: string) => {
 
 /**
  * 민원 생성
+ * @description 새로운 민원을 생성합니다
+ * @param data - 민원 생성 데이터 (userId, boardId, title, content, isPublic)
+ * @returns 생성된 민원 ID
  */
 export const create = async (data: ComplaintCreateDto) => {
   return await prisma.complaint.create({
@@ -64,6 +76,10 @@ export const create = async (data: ComplaintCreateDto) => {
 
 /**
  * 민원 목록 조회 (페이지네이션 + 필터링)
+ * @description 게시판의 민원 목록을 조회합니다. 쿼리에 따라 필터링 및 페이지네이션 적용
+ * @param boardId - 게시판 ID
+ * @param query - 목록 조회 쿼리 (status, isPublic, dong, ho, keyword, page, limit)
+ * @returns 민원 목록 (작성자, 댓글 수 포함, 내용 제외)
  */
 export const getList = async (boardId: string, query: ComplaintListQuery) => {
   const whereConditions = buildComplaintWhereConditions(boardId, query);
@@ -104,6 +120,10 @@ export const getList = async (boardId: string, query: ComplaintListQuery) => {
 
 /**
  * 민원 총 개수 조회 (필터링 적용)
+ * @description 게시판의 민원 총 개수를 조회합니다. 쿼리 필터링 조건 적용
+ * @param boardId - 게시판 ID
+ * @param query - 목록 조회 쿼리 (status, isPublic, dong, ho, keyword)
+ * @returns 필터링된 민원 총 개수
  */
 export const getCount = async (boardId: string, query: ComplaintListQuery) => {
   const whereConditions = buildComplaintWhereConditions(boardId, query);
@@ -115,6 +135,9 @@ export const getCount = async (boardId: string, query: ComplaintListQuery) => {
 
 /**
  * 민원 상세 조회 (조회수 증가 없음 - 권한 검증용)
+ * @description 민원 상세 정보를 조회합니다. 조회수를 증가시키지 않음 (권한 검증 후 증가)
+ * @param complaintId - 민원 ID
+ * @returns 민원 상세 정보 (작성자, 댓글 목록 포함) 또는 null
  */
 export const getByIdWithoutIncrement = async (complaintId: string) => {
   return await prisma.complaint.findUnique({
@@ -166,6 +189,9 @@ export const getByIdWithoutIncrement = async (complaintId: string) => {
 
 /**
  * 민원 조회수 증가
+ * @description 민원의 조회수를 1 증가시킵니다
+ * @param complaintId - 민원 ID
+ * @returns void
  */
 export const incrementViewCount = async (complaintId: string) => {
   await prisma.complaint.update({
@@ -180,6 +206,9 @@ export const incrementViewCount = async (complaintId: string) => {
 
 /**
  * 민원 ID로 작성자 ID 조회
+ * @description 민원의 작성자 ID와 상태를 조회합니다. 작성자 본인 확인 시 사용
+ * @param complaintId - 민원 ID
+ * @returns 작성자 ID와 상태 또는 null
  */
 export const getUserIdByComplaintId = async (complaintId: string) => {
   return await prisma.complaint.findUnique({
@@ -193,6 +222,9 @@ export const getUserIdByComplaintId = async (complaintId: string) => {
 
 /**
  * 민원 ID로 게시판 정보 조회 (권한 체크용)
+ * @description 민원이 속한 아파트의 관리자 ID를 조회합니다. ADMIN 권한 확인 시 사용
+ * @param complaintId - 민원 ID
+ * @returns 아파트 관리자 ID (없으면 undefined)
  */
 export const getComplaintWithBoardInfo = async (complaintId: string) => {
   const adminId = await prisma.complaint.findUnique({
@@ -216,6 +248,10 @@ export const getComplaintWithBoardInfo = async (complaintId: string) => {
 
 /**
  * 민원 내용 수정 (제목, 내용, 공개여부)
+ * @description 민원의 제목, 내용, 공개여부를 수정합니다
+ * @param complaintId - 민원 ID
+ * @param data - 수정할 데이터 (title, content, isPublic 중 1개 이상)
+ * @returns 수정된 민원 정보 (작성자, 댓글 수 포함)
  */
 export const patch = async (complaintId: string, data: ComplaintPatchDto) => {
   return await prisma.complaint.update({
@@ -252,6 +288,10 @@ export const patch = async (complaintId: string, data: ComplaintPatchDto) => {
 
 /**
  * 민원 상태 변경 (관리자 전용)
+ * @description 민원의 처리 상태를 변경합니다 (PENDING, IN_PROGRESS, COMPLETED, REJECTED)
+ * @param complaintId - 민원 ID
+ * @param data - 변경할 상태 (ComplaintStatus)
+ * @returns 상태가 변경된 민원 상세 정보 (작성자, 댓글 목록 포함)
  */
 export const patchStatus = async (complaintId: string, data: ComplaintStatus) => {
   return await prisma.complaint.update({
@@ -303,8 +343,13 @@ export const patchStatus = async (complaintId: string, data: ComplaintStatus) =>
   });
 };
 
+// ==================== 민원 삭제 ====================
+
 /**
  * 민원 삭제
+ * @description 민원을 삭제합니다
+ * @param complaintId - 민원 ID
+ * @returns void
  */
 export const deleteComplaint = async (complaintId: string) => {
   await prisma.complaint.delete({

--- a/src/modules/complaints/complaints.router.ts
+++ b/src/modules/complaints/complaints.router.ts
@@ -20,11 +20,28 @@ import {
 
 const router = Router();
 
+/**
+ * POST /complaints
+ * 민원 생성 (USER만 가능)
+ *
+ * GET /complaints
+ * 민원 목록 조회 (ADMIN, USER)
+ */
 router
   .route('/')
   .post(authMiddleware, requireRole(['USER']), validateComplaintCreate, createComplaintHandler)
   .get(authMiddleware, requireRole(['ADMIN', 'USER']), validateComplaintListQuery, getComplaintListHandler);
 
+/**
+ * GET /complaints/:complaintId
+ * 민원 상세 조회 (ADMIN, USER)
+ *
+ * PATCH /complaints/:complaintId
+ * 민원 수정 - 본인이 작성한 민원만 수정 가능 (USER만 가능)
+ *
+ * DELETE /complaints/:complaintId
+ * 민원 삭제 - USER: 본인만, ADMIN: 관리 아파트 모든 민원
+ */
 router
   .route('/:complaintId')
   .get(authMiddleware, requireRole(['ADMIN', 'USER']), validateComplaintParams, getComplaintHandler)
@@ -37,6 +54,10 @@ router
     deleteComplaintHandler
   );
 
+/**
+ * PATCH /complaints/:complaintId/status
+ * 민원 상태 변경 (ADMIN만 가능)
+ */
 router
   .route('/:complaintId/status')
   .patch(

--- a/src/modules/complaints/complaints.service.ts
+++ b/src/modules/complaints/complaints.service.ts
@@ -19,6 +19,10 @@ import { COMPLAINT_ERROR_MESSAGES } from '#constants/complaint.constant';
 
 /**
  * 민원 생성
+ * @description USER가 민원을 생성합니다. 본인이 속한 아파트의 게시판에만 민원 작성 가능
+ * @param data - 민원 생성 데이터 (userId, boardId, title, content, isPublic)
+ * @returns void
+ * @throws ApiError.forbidden - 게시판 권한 없음 (다른 아파트 게시판에 작성 시도)
  */
 export const createComplaint = async (data: ComplaintCreateDto) => {
   // 사용자의 게시판 권한 검증
@@ -33,6 +37,14 @@ export const createComplaint = async (data: ComplaintCreateDto) => {
 
 /**
  * 민원 목록 조회 (페이지네이션)
+ * @description 권한에 따라 민원 목록을 조회합니다
+ *   - USER: 본인이 속한 아파트 게시판의 민원 목록 (공개 민원 + 본인 작성 민원)
+ *   - ADMIN: 관리하는 아파트의 모든 민원 목록
+ * @param userId - 사용자 ID
+ * @param role - 사용자 역할 (USER | ADMIN)
+ * @param query - 목록 조회 쿼리 (status, page, limit)
+ * @returns 민원 목록과 전체 개수 { complaints: ComplaintListItemResponse[], totalCount: number }
+ * @throws ApiError.forbidden - 게시판 없음 (ADMIN이 관리하는 아파트가 없는 경우)
  */
 export const getComplaintList = async (userId: string, role: UserRole, query: ComplaintListQuery) => {
   // 사용자의 게시판 ID 조회
@@ -73,6 +85,16 @@ export const getComplaintList = async (userId: string, role: UserRole, query: Co
 
 /**
  * 민원 상세 조회 (조회수 증가)
+ * @description 민원 상세 정보를 조회합니다. 권한 검증 후 조회수를 증가시킵니다
+ *   - USER: 본인이 속한 아파트 게시판의 민원만 조회 가능, 비공개 민원은 작성자만 조회 가능
+ *   - ADMIN: 관리하는 아파트의 모든 민원 조회 가능
+ *   - 조회수는 작성자 본인이 아닐 때만 증가
+ * @param complaintId - 민원 ID
+ * @param userId - 사용자 ID
+ * @param role - 사용자 역할 (USER | ADMIN)
+ * @returns 민원 상세 정보 (ComplaintDetailResponse)
+ * @throws ApiError.notFound - 민원 없음
+ * @throws ApiError.forbidden - 조회 권한 없음 (다른 아파트 민원, 비공개 민원 등)
  */
 export const getComplaint = async (complaintId: string, userId: string, role: UserRole) => {
   // 1. 먼저 민원 조회 (조회수 증가 없이)
@@ -112,6 +134,14 @@ export const getComplaint = async (complaintId: string, userId: string, role: Us
 
 /**
  * 민원 수정 (제목, 내용, 공개여부)
+ * @description USER가 본인이 작성한 민원을 수정합니다. PENDING 상태의 민원만 수정 가능
+ * @param complaintId - 민원 ID
+ * @param loginUserId - 로그인한 사용자 ID
+ * @param data - 수정할 데이터 (title, content, isPublic)
+ * @returns 수정된 민원 정보 (ComplaintListItemResponse)
+ * @throws ApiError.badRequest - 수정할 데이터 없음
+ * @throws ApiError.notFound - 민원 없음
+ * @throws ApiError.forbidden - 수정 권한 없음 (작성자 본인 아님), 또는 수정 불가 상태 (IN_PROGRESS, COMPLETED, REJECTED)
  */
 export const patchComplaint = async (complaintId: string, loginUserId: string, data: ComplaintPatchDto) => {
   // 수정할 내용이 있는지 확인
@@ -135,6 +165,12 @@ export const patchComplaint = async (complaintId: string, loginUserId: string, d
 
 /**
  * 민원 상태 변경 (관리자 전용)
+ * @description ADMIN이 민원의 상태를 변경합니다 (PENDING → IN_PROGRESS → COMPLETED 또는 REJECTED)
+ * @param complaintId - 민원 ID
+ * @param data - 상태 변경 데이터 (userId, status)
+ * @returns 상태가 변경된 민원 정보 (ComplaintDetailResponse)
+ * @throws ApiError.notFound - 민원 없음
+ * @throws ApiError.forbidden - 권한 없음 (관리하는 아파트의 민원이 아님)
  */
 export const patchComplaintStatus = async (complaintId: string, data: ComplaintPatchStatusDto) => {
   // 관리자 권한 확인
@@ -148,6 +184,14 @@ export const patchComplaintStatus = async (complaintId: string, data: ComplaintP
 
 /**
  * 민원 삭제
+ * @description 권한에 따라 민원을 삭제합니다
+ *   - USER: 본인이 작성한 PENDING 상태 민원만 삭제 가능
+ *   - ADMIN: 관리하는 아파트의 모든 민원 삭제 가능 (상태 무관)
+ * @param complaintId - 민원 ID
+ * @param userData - 사용자 데이터 (userId, role)
+ * @returns void
+ * @throws ApiError.notFound - 민원 없음
+ * @throws ApiError.forbidden - 삭제 권한 없음 (작성자 본인 아님, 또는 USER의 경우 PENDING 상태 아님)
  */
 export const deleteComplaint = async (complaintId: string, userData: ComplaintDeleteDto) => {
   if (userData.role === UserRole.USER) {

--- a/src/modules/complaints/complaints.validator.ts
+++ b/src/modules/complaints/complaints.validator.ts
@@ -9,6 +9,10 @@ import {
 import { complaintListQuerySchema } from './dto/querys.dto';
 import { complaintParamsSchema } from './dto/params.dto';
 
+/**
+ * 민원 생성 요청 검증
+ * req.user와 req.body를 결합하여 Zod 스키마로 검증 후 res.locals.validatedBody에 저장
+ */
 export const validateComplaintCreate = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const validatedBody = await complaintCreateSchema.parseAsync({
@@ -23,6 +27,10 @@ export const validateComplaintCreate = async (req: Request, res: Response, next:
   }
 };
 
+/**
+ * 민원 목록 조회 쿼리 검증
+ * req.query를 Zod 스키마로 검증 후 res.locals.validatedQuery에 저장
+ */
 export const validateComplaintListQuery = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const validatedQuery = await complaintListQuerySchema.parseAsync(req.query);
@@ -34,6 +42,10 @@ export const validateComplaintListQuery = async (req: Request, res: Response, ne
   }
 };
 
+/**
+ * 민원 params 검증
+ * req.params.complaintId를 Zod 스키마로 검증
+ */
 export const validateComplaintParams = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { complaintId } = req.params;
@@ -44,6 +56,10 @@ export const validateComplaintParams = async (req: Request, res: Response, next:
   }
 };
 
+/**
+ * 민원 수정 요청 검증
+ * req.body를 Zod 스키마로 검증 후 res.locals.validatedBody에 저장
+ */
 export const validateComplaintPatch = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const validatedBody = await complaintPatchSchema.parseAsync(req.body);
@@ -55,6 +71,10 @@ export const validateComplaintPatch = async (req: Request, res: Response, next: 
   }
 };
 
+/**
+ * 민원 상태 변경 요청 검증
+ * req.user와 req.body를 결합하여 Zod 스키마로 검증
+ */
 export const validateComplaintPatchStatus = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const validatedBody = await complaintPatchStatusSchema.parseAsync({
@@ -69,6 +89,10 @@ export const validateComplaintPatchStatus = async (req: Request, res: Response, 
   }
 };
 
+/**
+ * 민원 삭제 요청 검증
+ * req.user를 Zod 스키마로 검증 후 res.locals.validatedBody에 저장
+ */
 export const validateComplaintDelete = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const validatedBody = await complaintDeleteSchema.parseAsync({


### PR DESCRIPTION
# docs(complaint): 민원 API 전체 레이어에 JSDoc 주석 추가

## 📝 Summary
민원(Complaint) 모듈의 모든 레이어(Router, Controller, Service, Repository, Validator, Util)에 JSDoc 주석을 추가하여 코드 가독성과 유지보수성을 향상시켰습니다.

## 🎯 변경 사항

**총 211줄의 주석 추가**

각 파일별로 추가된 주석은 다음과 같습니다:

### 1. **Router** ([complaints.router.ts](src/modules/complaints/complaints.router.ts))
- 각 라우트 그룹별 기능 설명 추가
- HTTP 메서드와 권한 요구사항 명시
- 엔드포인트별 접근 권한 (USER/ADMIN) 설명

### 2. **Controller** ([complaints.controller.ts](src/modules/complaints/complaints.controller.ts))
- 6개 핸들러 함수에 JSDoc 추가
- 각 핸들러의 역할과 권한 요구사항 명시
- 반환값(HTTP 상태 코드)과 발생 가능한 예외(ApiError) 문서화

### 3. **Service** ([complaints.service.ts](src/modules/complaints/complaints.service.ts))
- 5개 서비스 함수에 상세한 JSDoc 추가
- 비즈니스 로직과 권한 검증 흐름 설명
- 파라미터, 반환값, 예외 상황 문서화

### 4. **Repository** ([complaints.repo.ts](src/modules/complaints/complaints.repo.ts))
- 11개 DB 쿼리 함수에 JSDoc 추가
- Prisma 쿼리의 목적과 반환 데이터 구조 명시
- 각 함수의 사용 시나리오 설명

### 5. **Validator** ([complaints.validator.ts](src/modules/complaints/complaints.validator.ts))
- 6개 미들웨어 검증 함수에 JSDoc 추가
- Zod 스키마 검증 과정과 `res.locals` 저장 로직 설명
- 각 검증 대상(body, query, params) 명시

### 6. **Utility** ([complaints.util.ts](src/modules/complaints/complaints.util.ts))
- 6개 유틸리티 함수에 JSDoc 추가
- 권한 검증 로직 상세 설명
- 응답 매핑 함수의 변환 로직 문서화

## ✨ 개선 효과

### 1. **코드 가독성 향상**
- 각 함수의 목적과 동작을 주석으로 명확히 파악 가능
- IDE의 IntelliSense를 통한 빠른 함수 이해

### 2. **유지보수성 향상**
- 권한 로직과 비즈니스 규칙이 명확히 문서화됨
- 신규 개발자의 온보딩 시간 단축

### 3. **API 문서화**
- 각 엔드포인트의 권한 요구사항과 동작 방식 명시
- 예외 처리 상황(`@throws`)이 명확히 문서화됨
