### PR TITLE
feat: morgan 기반 HTTP request logger 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@types/jest": "^30.0.0",
         "@types/jsdom": "^27.0.0",
         "@types/jsonwebtoken": "^9.0.10",
+        "@types/morgan": "^1.9.10",
         "@types/multer": "^2.0.0",
         "@types/supertest": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^8.46.1",
@@ -4395,6 +4396,16 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/morgan": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/jest": "^30.0.0",
     "@types/jsdom": "^27.0.0",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/morgan": "^1.9.10",
     "@types/multer": "^2.0.0",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.46.1",

--- a/src/core/app.ts
+++ b/src/core/app.ts
@@ -18,6 +18,7 @@ import rateLimit from 'express-rate-limit';
 import routes from '#core/router';
 import { errorHandler } from '#middlewares/errorHandler';
 import corsMiddleware from '#core/middlewares/cors';
+import httpLogger from '#core/httpLogger';
 import ApiError from '#errors/ApiError';
 
 const app: Application = express();
@@ -80,6 +81,11 @@ app.use(compression());
  * CORS (화이트리스트 기반)
  */
 app.use(corsMiddleware);
+
+/**
+ * HTTP 요청 로거 (morgan + pino)
+ */
+app.use(httpLogger);
 
 /**
  * Body & Cookie 파서

--- a/src/core/httpLogger.ts
+++ b/src/core/httpLogger.ts
@@ -1,0 +1,42 @@
+/**
+ * @file #core/httpLogger.ts
+ * @description HTTP 요청 로깅용 모듈 (morgan + pino)
+ */
+
+import fs from 'fs';
+import path from 'path';
+import morgan from 'morgan';
+import { logger } from '#core/logger';
+
+/**
+ * 로그 파일 경로 설정
+ */
+const logDir = path.resolve('logs');
+if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
+const accessLogStream = fs.createWriteStream(path.join(logDir, 'access.log'), { flags: 'a' });
+
+/**
+ * 로그 포맷 정의
+ * @example
+ * 2025-10-29 11:03:01 [HTTP] GET /api/users 200 45ms - 123b
+ */
+const format = ':date[iso] [HTTP] :method :url :status :response-time ms - :res[content-length]';
+
+/**
+ * Morgan 미들웨어 생성
+ * - 콘솔: Pino logger와 함께 출력
+ * - 파일: logs/access.log에 저장
+ */
+const httpLogger = morgan(format, {
+  stream: {
+    write: (message: string) => {
+      // 콘솔
+      logger.http.info(message.trim());
+
+      // 파일
+      accessLogStream.write(message);
+    },
+  },
+});
+
+export default httpLogger;

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -149,6 +149,7 @@ export const logger = Object.assign(baseLogger, {
 
   // 전체 시스템 수준 로그
   sse: createDomainLogger('sse'),
+  http: createDomainLogger('http'),
   system: createDomainLogger('system'),
 });
 


### PR DESCRIPTION
## 주요 변경 사항
- Morgan 기반 HTTP request logger를 추가했습니다.
  - logs/access.log 파일에 요청 로그 기록
  - Pino logger와 콘솔 출력 병행
- `app.ts`에 httpLogger 미들웨어를 적용했습니다.

## 추가 변경 사항
- `core/logger.ts`에 http 로그를 추가했습니다.

## 참고사항
- 의존성 1종 추가되어 `npm install` 필요합니다.
- 로그 예시: [system] 09:25:43 [HTTP] GET /api/users 200 45ms - 123b
- TODO: 가능하다면 httpLogger에 request IP 추가 (프론트-백엔드 구조 문제로 확정 불가)