### PR TITLE
chore(core): app.ts의 중복 .env 로드 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .env.test
 .DS_Store
 coverage
+logs/access.log

--- a/src/core/app.ts
+++ b/src/core/app.ts
@@ -1,13 +1,3 @@
-import dotenv from 'dotenv';
-import fs from 'fs';
-
-/**
- * 환경 변수 로드
- */
-const envPath = process.env.NODE_ENV === 'production' ? '.env.production' : '.env';
-if (fs.existsSync(envPath)) dotenv.config({ path: envPath });
-else dotenv.config();
-
 import express, { Application, Request, Response, NextFunction } from 'express';
 import helmet from 'helmet';
 import hpp from 'hpp';
@@ -15,6 +5,7 @@ import compression from 'compression';
 import cookieParser from 'cookie-parser';
 import rateLimit from 'express-rate-limit';
 
+import env from '#core/env';
 import routes from '#core/router';
 import { errorHandler } from '#middlewares/errorHandler';
 import corsMiddleware from '#core/middlewares/cors';
@@ -40,7 +31,7 @@ app.use(
         'default-src': ["'self'"],
         'script-src': ["'self'", "'unsafe-inline'"],
         'style-src': ["'self'", "'unsafe-inline'"],
-        'img-src': ["'self'", 'data:', 'https:', ...(process.env.NODE_ENV !== 'production' ? ['http:', 'blob:'] : [])],
+        'img-src': ["'self'", 'data:', 'https:', ...(env.NODE_ENV !== 'production' ? ['http:', 'blob:'] : [])],
         'object-src': ["'none'"],
         'frame-ancestors': ["'none'"],
       },


### PR DESCRIPTION
## 주요 변경 사항
- `env.ts`에서 dotenv가 로드되기에, `app.ts`의 직접 호출을 제거했습니다.
  - 환경 변수 초기화를 `env.ts` 단일 진입점으로 통일

## 추가 변경 사항
- 관련 테스트 과정에서 서버 실행 시 `logs/access.log` 파일이 생성되어, 해당 파일 추적 제외하도록 `.gitignore`에 추가했습니다.