### PR TITLE
chore(complaint): 민원 CRUD API  router연결 및 테스트 완료

### DIFF
--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -10,6 +10,7 @@ import sseRouter from '#sse/index';
  * 도메인 레벨 (modules)
  */
 import authRouter from '#modules/auth/auth.router';
+import complaintRouter from '#modules/complaints/complaints.router';
 import noticeRouter from '#modules/notices/notices.router';
 
 const router = Router();
@@ -24,6 +25,7 @@ router.use('/notifications', sseRouter);
  * 도메인 계층 라우트
  */
 router.use('/auth', authRouter);
+router.use('/complaints', complaintRouter);
 router.use('/notices', noticeRouter);
 
 export default router;

--- a/src/modules/complaints/complaints.router.ts
+++ b/src/modules/complaints/complaints.router.ts
@@ -18,7 +18,7 @@ import {
   deleteComplaintHandler,
 } from './complaints.controller';
 
-const router = Router();
+const complaintRouter = Router();
 
 /**
  * POST /complaints
@@ -27,7 +27,7 @@ const router = Router();
  * GET /complaints
  * 민원 목록 조회 (ADMIN, USER)
  */
-router
+complaintRouter
   .route('/')
   .post(authMiddleware, requireRole(['USER']), validateComplaintCreate, createComplaintHandler)
   .get(authMiddleware, requireRole(['ADMIN', 'USER']), validateComplaintListQuery, getComplaintListHandler);
@@ -42,7 +42,7 @@ router
  * DELETE /complaints/:complaintId
  * 민원 삭제 - USER: 본인만, ADMIN: 관리 아파트 모든 민원
  */
-router
+complaintRouter
   .route('/:complaintId')
   .get(authMiddleware, requireRole(['ADMIN', 'USER']), validateComplaintParams, getComplaintHandler)
   .patch(authMiddleware, requireRole(['USER']), validateComplaintParams, validateComplaintPatch, patchComplaintHandler)
@@ -58,7 +58,7 @@ router
  * PATCH /complaints/:complaintId/status
  * 민원 상태 변경 (ADMIN만 가능)
  */
-router
+complaintRouter
   .route('/:complaintId/status')
   .patch(
     authMiddleware,
@@ -68,4 +68,4 @@ router
     patchComplaintStatusHandler
   );
 
-export default router;
+export default complaintRouter;


### PR DESCRIPTION
## 📋 Summary
민원(Complaint) 관리 시스템의 전체 CRUD API 라우터 연결 및 통합 테스트를 완료했습니다.

## ✨ 주요 구현 사항

### 1. API 엔드포인트
- **POST** `/complaints` - 민원 생성 (USER 권한)
- **GET** `/complaints` - 민원 목록 조회 (ADMIN, USER 권한)
- **GET** `/complaints/:complaintId` - 민원 상세 조회 (ADMIN, USER 권한)
- **PATCH** `/complaints/:complaintId` - 민원 수정 (USER 권한, 본인 작성만)
- **PATCH** `/complaints/:complaintId/status` - 민원 상태 변경 (ADMIN 권한)
- **DELETE** `/complaints/:complaintId` - 민원 삭제 (USER: 본인만, ADMIN: 관리 아파트 전체)

### 2. 기능 특징
- **권한 기반 접근 제어**: USER/ADMIN 역할별 세밀한 권한 관리
- **소유권 검증**: USER는 본인이 작성한 민원만 수정/삭제 가능
- **관리자 범위 제한**: ADMIN은 관리하는 아파트의 민원만 접근 가능
- **조회수 자동 증가**: 민원 상세 조회 시 viewCount 자동 업데이트
- **Zod 기반 유효성 검증**: 모든 요청에 대한 입력값 검증

## 🧪 Test Plan
- [x] 민원 생성 (공개/비공개)

<img width="1042" height="609" alt="민원 생성" src="https://github.com/user-attachments/assets/49caa429-7b58-447b-b694-e63838980bd3" />


- [x] 민원 목록 조회 (페이지네이션)

<img width="988" height="886" alt="전체 민원 조회" src="https://github.com/user-attachments/assets/1a1882d6-1183-4ab6-9bb5-87e0eeb14c3a" />


- [x] 민원 상세 조회 (조회수 증가 확인)

<img width="969" height="834" alt="민원 상세 조회" src="https://github.com/user-attachments/assets/8658e237-5344-41a4-91cb-d199d9929345" />


- [x] 민원 수정 (본인 확인)

<img width="977" height="856" alt="일반 유저민원 수정" src="https://github.com/user-attachments/assets/044566a8-c66e-43a9-adfb-a84c3d1deeb9" />


- [x] 민원 상태 변경 (ADMIN 권한)

<img width="981" height="877" alt="민원상태 수정" src="https://github.com/user-attachments/assets/5ef93a27-2c0c-49a0-a3f8-8818db55105f" />


- [x] 민원 삭제 (권한별 동작 확인)

<img width="976" height="629" alt="민원 삭제" src="https://github.com/user-attachments/assets/15d2c4b7-f2ae-4b90-ba87-e4e724363033" />
