### PR TITLE
chore(comment): 댓글 CUD API router연결 및 테스트 완료

### DIFF
--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -12,6 +12,7 @@ import sseRouter from '#sse/index';
 import authRouter from '#modules/auth/auth.router';
 import complaintRouter from '#modules/complaints/complaints.router';
 import noticeRouter from '#modules/notices/notices.router';
+import commentRouter from '#modules/comments/comments.router';
 
 const router = Router();
 
@@ -27,5 +28,6 @@ router.use('/notifications', sseRouter);
 router.use('/auth', authRouter);
 router.use('/complaints', complaintRouter);
 router.use('/notices', noticeRouter);
+router.use('/comments', commentRouter);
 
 export default router;

--- a/src/modules/comments/comments.router.ts
+++ b/src/modules/comments/comments.router.ts
@@ -4,13 +4,15 @@ import requireRole from '#middlewares/requireRole';
 import { validateCommentCreate, validateCommentPatch, validateCommentDelete } from './comments.validator';
 import { createCommentHandler, patchCommentHandler, deleteCommentHandler } from './comments.controller';
 
-const router = Router();
+const commentRouter = Router();
 
 /**
  * POST /comments
  * 댓글 생성 (ADMIN, USER)
  */
-router.route('/').post(authMiddleware, requireRole(['ADMIN', 'USER']), validateCommentCreate, createCommentHandler);
+commentRouter
+  .route('/')
+  .post(authMiddleware, requireRole(['ADMIN', 'USER']), validateCommentCreate, createCommentHandler);
 
 /**
  * PATCH /comments/:commentId
@@ -19,7 +21,9 @@ router.route('/').post(authMiddleware, requireRole(['ADMIN', 'USER']), validateC
  * DELETE /comments/:commentId
  * 댓글 삭제 - USER: 본인 댓글만, ADMIN: 관리 아파트 모든 댓글
  */
-router
+commentRouter
   .route('/:commentId')
   .patch(authMiddleware, requireRole(['ADMIN', 'USER']), validateCommentPatch, patchCommentHandler)
   .delete(authMiddleware, requireRole(['ADMIN', 'USER']), validateCommentDelete, deleteCommentHandler);
+
+export default commentRouter;


### PR DESCRIPTION
## 📋 Summary
댓글(Comment) 관리 시스템의 생성, 수정, 삭제(CUD) API 라우터 연결 및 통합 테스트를 완료했습니다.

## ✨ 주요 구현 사항

### 1. API 엔드포인트
- **POST** `/comments` - 댓글 생성 (ADMIN, USER 권한)
- **PATCH** `/comments/:commentId` - 댓글 수정 (ADMIN, USER 권한, 본인 작성만)
- **DELETE** `/comments/:commentId` - 댓글 삭제 (USER: 본인만, ADMIN: 관리 아파트 전체)

### 2. 기능 특징
- **권한 기반 접근 제어**: USER/ADMIN 역할별 세밀한 권한 관리
- **소유권 검증**: USER는 본인이 작성한 댓글만 수정/삭제 가능
- **관리자 범위 제한**: ADMIN은 관리하는 아파트의 댓글만 삭제 가능
- **게시글 연동**: 민원(Complaint) 또는 공지사항(Notice) 게시글에 댓글 작성
- **Zod 기반 유효성 검증**: 모든 요청에 대한 입력값 검증
- **계층형 구조**: boardType과 boardId를 통한 다양한 게시판 타입 지원

## 🧪 Test Plan
- [x] 댓글 생성 (민원/공지사항)

<img width="971" height="820" alt="댓글 생성" src="https://github.com/user-attachments/assets/1e7114c2-bf1c-4e7c-bf1c-7321560f17b0" />


- [x] 댓글 수정 (본인 확인)

<img width="1049" height="838" alt="댓글 수정" src="https://github.com/user-attachments/assets/456f549a-c487-4e15-8cce-6c5da53bfa4c" />


- [x] 댓글 삭제 (권한별 동작 확인)

<img width="991" height="462" alt="댓글 삭제" src="https://github.com/user-attachments/assets/a4b51581-1e51-4247-a3aa-3bd205b4e537" />

