### PR TITLE
fix(db): Complaint, Notice, Poll Apartment에서 apartment로 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -213,7 +213,7 @@ model Notice {
 
   comments Comment[]
 
-  Apartment   Apartment? @relation(fields: [apartmentId], references: [id], onDelete: Cascade)
+  apartment   Apartment? @relation(fields: [apartmentId], references: [id], onDelete: Cascade)
   apartmentId String?
   Event       Event?
 }
@@ -239,7 +239,7 @@ model Complaint {
 
   comments Comment[]
 
-  Apartment   Apartment? @relation(fields: [apartmentId], references: [id], onDelete: Cascade)
+  apartment   Apartment? @relation(fields: [apartmentId], references: [id], onDelete: Cascade)
   apartmentId String?
 }
 
@@ -264,7 +264,7 @@ model Poll {
   options PollOption[]
   votes   PollVote[]
 
-  Apartment   Apartment? @relation(fields: [apartmentId], references: [id], onDelete: Cascade)
+  apartment   Apartment? @relation(fields: [apartmentId], references: [id], onDelete: Cascade)
   apartmentId String?
   Event       Event?
 }


### PR DESCRIPTION
## 주요 변경 사항
- `Complaint`, `Notice`, `Poll` Model의 필드명을 `Apartment`에서 `apartment`로 수정했습니다.

## 참고 사항
- migration 파일이 변경되지는 않기에, `git pull` 후 수동으로 `migrate` 진행하셔야 합니다.