### PR TITLE
fix: notice query schema optional() 추가

### DIFF
--- a/src/modules/notices/dto/notices.dto.ts
+++ b/src/modules/notices/dto/notices.dto.ts
@@ -16,8 +16,8 @@ type CommentDTO = {
 export const noticeParamsSchema = z.uuid({ message: '유효한 경로가 아닙니다.' });
 
 export const noticeListQuerySchema = z.object({
-  page: z.number().gt(1),
-  pageSize: z.number().gt(5),
+  page: z.number().gte(1).optional(),
+  pageSize: z.number().gte(5).optional(),
   category: z.enum(['MAINTENANCE', 'EMERGENCY', 'COMMUNITY', 'RESIDENT_VOTE', 'RESIDENT_COUNCIL', 'COMPLAINT', 'ETC']),
   search: z.string().optional().nullable(),
 });


### PR DESCRIPTION
## 주요 변경 사항

export const noticeListQuerySchema = z.object({
  page: z.number().gte(1),
  pageSize: z.number().gte(5),
  category: z.enum(['MAINTENANCE', 'EMERGENCY', 'COMMUNITY', 'RESIDENT_VOTE', 'RESIDENT_COUNCIL', 'COMPLAINT', 'ETC']),
  search: z.string().optional().nullable(),
});

=>

export const noticeListQuerySchema = z.object({
  page: z.number().gte(1).optional(),
  pageSize: z.number().gte(5).optional(),
  category: z.enum(['MAINTENANCE', 'EMERGENCY', 'COMMUNITY', 'RESIDENT_VOTE', 'RESIDENT_COUNCIL', 'COMPLAINT', 'ETC']),
  search: z.string().optional().nullable(),
});