### PR TITLE
fix(test): HTTP Logger 테스트 안정화 (로그 파일 생성 대기 추가)

### DIFF
--- a/tests/core/httpLogger.test.ts
+++ b/tests/core/httpLogger.test.ts
@@ -24,6 +24,13 @@ describe('[Core] HTTP Logger (morgan + pino)', () => {
 
   it('HTTP 요청 시 로그 파일에 기록되어야 함', async () => {
     await request(app).get('/ping');
+
+    // 로그 파일 생성 대기 (최대 1초)
+    for (let i = 0; i < 10; i++) {
+      if (fs.existsSync(logPath)) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
     expect(fs.existsSync(logPath)).toBe(true);
 
     const content = fs.readFileSync(logPath, 'utf-8');


### PR DESCRIPTION
## 주요 변경 사항
- `httpLogger.test.ts` 테스트를 안정화했습니다.
  - 로그 파일 생성 타이밍 문제를 해결했습니다.
  - 테스트 요청 직후 `morgan/pino`의 비동기 스트림이 파일을 생성하기 전에 테스트가 실행되어 간헐적으로 실패하는 문제가 있었습니다.
  - 로그 파일이 실제로 생성될 때까지 최대 1초(100ms × 10회) 대기하도록 수정했습니다.

## 참고 사항
- 본 변경은 테스트 로직만 수정되며, 실제 로거(`httpLogger`) 구현에는 영향을 주지 않습니다.
- 테스트 환경에서는 `pino.destination({ sync: true })`로 동기 로깅 전환도 가능하지만,
실제 서비스 동작 환경과의 동작 차이를 피하기 위해 적용하지 않았습니다.