### PR TITLE
fix: Query Schema, Query DTO 분리

### DIFF
--- a/src/modules/notices/dto/notices.dto.ts
+++ b/src/modules/notices/dto/notices.dto.ts
@@ -24,7 +24,12 @@ export const noticeListQuerySchema = z.object({
   search: z.string().optional().nullable(),
 });
 
-export type NoticeListQueryDTO = z.infer<typeof noticeListQuerySchema>;
+export type NoticeListQueryDTO = {
+  page: number;
+  pageSize: number;
+  category: NoticeCategory;
+  search: string | null;
+};
 
 export const noticeCreateSchema = z.object({
   userId: z.uuid({ message: '유효한 사용자 ID가 아닙니다.' }),

--- a/src/modules/notices/notices.controller.ts
+++ b/src/modules/notices/notices.controller.ts
@@ -41,8 +41,8 @@ export const getNoticeList: RequestHandler = async (req, res, next) => {
     const query = res.locals.query as NoticeListQueryDTO;
     const { page, pageSize, category, search } = query;
     const dto: NoticeListQueryDTO = {
-      page: page ? Number(page) : PAGINATION.DEFAULT_PAGE,
-      pageSize: pageSize ? Number(pageSize) : PAGINATION.DEFAULT_LIMIT,
+      page: Number(page) ?? PAGINATION.DEFAULT_PAGE,
+      pageSize: Number(pageSize) ?? PAGINATION.DEFAULT_LIMIT,
       category: category as NoticeCategory,
       search: search ?? null,
     };


### PR DESCRIPTION
## 주요 변경 사항
- query schema에선 z.string으로 검사하도록 하고, schema와 DTO를 분리하여 데이터를 넘겨줄 때는 number 타입이 되도록 수정했습니다.