### PR TITLE
chore(docker): docker-compose 설정 안정화 및 로깅 개선

### DIFF
--- a/infra/docker/docker-compose.yaml
+++ b/infra/docker/docker-compose.yaml
@@ -3,19 +3,22 @@ version: '3.9'
 services:
   # PostgreSQL 데이터베이스 서비스
   db:
-    image: postgres
+    image: postgres:15-alpine
     restart: always
-    ports:
-      - '5432:5432'
     volumes:
-      - db:/var/lib/postgresql/data
+      - welive_db:/var/lib/postgresql/data
     env_file:
-      - ../.env
+      - ../../.env
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
       interval: 5s
       timeout: 3s
       retries: 10
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '3'
 
   # Node.js 애플리케이션 서비스
   web:
@@ -29,10 +32,21 @@ services:
       db:
         condition: service_healthy
     env_file:
-      - ../.env
-    # volumes:
-    #   - uploads:/app/uploads
+      - ../../.env
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3001/api']
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '3'
 
 volumes:
-  db:
-  # uploads:
+  welive_db:
+
+networks:
+  default:
+    name: welive_network


### PR DESCRIPTION
## 주요 변경 사항
- PostgreSQL 이미지 버전을 latest에서 `15-alpine`으로 고정했습니다.
- `.env` 경로를 `infra/docker` 기준에 맞춰 `../../.env`로 수정했습니다.
- `db`, `web` 서비스에 `json-file` 로그 롤링 설정을 추가했습니다. (10MB x3)
- `web` 서비스에 헬스체크를 추가했습니다.
  - 엔드포인트: `/api`
 
## 참고 사항
- `/api` 엔드포인트는 `/api/health` 로 변경할지 고민 중입니다. (라우팅 꼬임 등 우려)