### PR TITLE
fix(infra): cd에 npm 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Deploy on EC2
         run: |
           ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} <<'EOF'
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
           set -e
 
           echo ""


### PR DESCRIPTION
## 주요 변경 사항
- cd 스크립트에 npm 경로가 지정되지 않아, `-bash: line 72: npm: command not found` 에러가 발생하던 문제를 해결했습니다.