### PR TITLE
fix(infra): Dockerfile @prisma/client 명시적으로 설치 추가

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN npm run build
 FROM base AS prod-deps
 COPY package*.json ./
 RUN npm ci --omit=dev \
-  && npm i --no-save prisma@6.17.1
+  && npm i --no-save prisma@6.17.1 @prisma/client
 
 # ---------- runtime ----------
 FROM base AS runtime


### PR DESCRIPTION
## 주요 변경 사항
- Prod 과정에서 @prisma/client가 누락되는 것 같아, Dockerfile에 명시적으로 설치 추가하였습니다.
```bash
    throw new Error('@prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.');