### PR TITLE
fix(infra): Dockerfile Prisma Client 생성 순서 조정

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -12,9 +12,6 @@ COPY tsconfig*.json ./
 COPY prisma ./prisma
 COPY src ./src
 
-# Prisma Client 생성
-RUN npx prisma generate --schema=prisma/schema.prisma
-
 # ---------- build (TS → CJS) ----------
 FROM deps AS build
 COPY prisma ./prisma
@@ -25,6 +22,9 @@ FROM base AS prod-deps
 COPY package*.json ./
 RUN npm ci --omit=dev \
   && npm i --no-save prisma@6.17.1 @prisma/client
+
+  # Prisma Client 생성
+RUN npx prisma generate --schema=prisma/schema.prisma
 
 # ---------- runtime ----------
 FROM base AS runtime


### PR DESCRIPTION
## 주요 변경 사항
- deps 단계의 node_modules가 런타임에서 사용되지 않아, 이 단계에서 generate한 `prisma/client`가 누락되는 것으로 파악되어  
  generate 단계를 수정했습니다.