### PR TITLE
fix(infra): 유저 권한 문제로 app/logs 폴더 사전 생성

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -31,6 +31,7 @@ ENV PORT=3001
 
 # non-root
 RUN addgroup -S app && adduser -S app -G app
+RUN mkdir -p /app/logs && chown -R app:app /app/logs
 USER app
 
 # deps / app


### PR DESCRIPTION
## 주요 변경 사항
- `logger`의 mkdir 권한 문제가 있어, Dockerfile에서 non-root user로 변경하기 전 `app/logs` 폴더를 생성하도록 추가했습니다.
  - 절대경로 → 상대경로 설정하는 방법도 있으나, root user로 생성하면 문제가 발생하기에 이 방법을 택함