### PR TITLE
refactor: SSE 환경에서의 Logger 수정

### DIFF
--- a/src/core/sse/sseEmitter.ts
+++ b/src/core/sse/sseEmitter.ts
@@ -10,6 +10,7 @@
 import * as SSE from './index';
 import type { NotificationPayload } from './types';
 import { logger } from '#core/logger';
+import env from '#core/env';
 
 /**
  * 전체 클라이언트에 알림 전송
@@ -34,6 +35,8 @@ export const sendSseNotification = (payload: NotificationPayload): void => {
  * - 민원 처리 완료, 투표 결과 등 사용자별 이벤트에서 사용
  */
 export const sendSseToUser = (userId: string, payload: NotificationPayload): void => {
+  if (env.NODE_ENV === 'test' && process.env.__ALLOW_SSE_TEST__ !== 'true') return;
+
   if (typeof SSE.sendToUser !== 'function') {
     logger.sse.warn(`SSE 라우터가 초기화되지 않아 개별 전송을 건너뜁니다. (userId=${userId})`);
     return;

--- a/tests/core/sse/sseEmitter.test.ts
+++ b/tests/core/sse/sseEmitter.test.ts
@@ -5,6 +5,7 @@ import { logger } from '#core/logger';
 import { NotificationType } from '@prisma/client';
 
 process.env.TEST_ALLOW_ACCESS_LOG = 'true';
+process.env.__ALLOW_SSE_TEST__ = 'true';
 
 jest.mock('#core/logger', () => {
   const mock = {
@@ -74,5 +75,6 @@ describe('[SSE Emitter] 브리지 기능 검증', () => {
 
   afterAll(() => {
     delete process.env.TEST_ALLOW_ACCESS_LOG;
+    delete process.env.__ALLOW_SSE_TEST__;
   });
 });


### PR DESCRIPTION
## 주요 변경 사항
- 테스트 환경에서 SSE Emitter가 logger를 미출력하도록 변경하였습니다.
- SSE Test에 한정하여 환경변수를 받아 일시적으로 출력합니다.

## 테스트 결과
Test Suites: 32 passed, 32 total
Tests:       197 passed, 197 total
Snapshots:   0 total
Time:        27.428 s
Ran all test suites.