### PR TITLE
fix(core): sanitize 초기화 시 swagger-autogen 빌드 무한대기 문제 해결

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN npx prisma generate --schema=prisma/schema.prisma
 RUN npm run build
 
 # generate swagger (CJS)
-RUN npm run swagger:generate
+RUN SWAGGER_BUILD=true npm run swagger:generate
 
 # ---------- runtime ----------
 FROM node:20-alpine AS runtime

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "npm run start:be && npm run start:fe",
     "stop": "pm2 delete welive-be || true && pm2 delete welive-fe || true",
     "_section7": "Swagger",
-    "swagger:generate": "node scripts/genSwagger.js"
+    "swagger:generate": "SWAGGER_BUILD=true node scripts/genSwagger.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 주요 변경 사항
- Sanitize에 `SWAGGER_BUILD=true` 플래그를 도입했습니다.
  - Swagger 빌드 시 Purifier를 NOOP으로 치환  
  - jsdom 및 DOMPurify는 서버 런타임에서만 lazy-load 실행