### PR TITLE
fix(swagger): sanitize import loop로 인한 OOM 해결

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN npx prisma generate --schema=prisma/schema.prisma
 RUN npm run build
 
 # generate swagger (CJS)
-RUN SWAGGER_BUILD=true npm run swagger:generate
+RUN npm run swagger:generate
 
 # ---------- runtime ----------
 FROM node:20-alpine AS runtime

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "npm run start:be && npm run start:fe",
     "stop": "pm2 delete welive-be || true && pm2 delete welive-fe || true",
     "_section7": "Swagger",
-    "swagger:generate": "SWAGGER_BUILD=true node scripts/genSwagger.js"
+    "swagger:generate": "cross-env SWAGGER_BUILD=true node scripts/genSwagger.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 개요
CD에서 Swagger 문서 생성 단계(`npm run swagger:generate`)에서
Node 힙 메모리(OOM)로 빌드가 중단되는 문제가 발생하여 이를 해결했습니다.

## 주요 변경 사항
- SWAGGER_BUILD=true 환경에서 sanitize 미들웨어를 NO-OP 처리했습니다.