### PR TITLE
fix(complaint): prisma 타입추론 한계 문제 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "welive",
-      "version": "1.0.1",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.911.0",

--- a/src/modules/complaints/complaints.repo.ts
+++ b/src/modules/complaints/complaints.repo.ts
@@ -1,5 +1,6 @@
 import prisma from '../../core/prisma';
 import { ComplaintCreateDto, ComplaintPatchDto } from './dto/complaints.dto';
+import { ComplaintRawResponseDto } from './dto/response.dto';
 import { ComplaintListQuery } from './dto/querys.dto';
 import { buildComplaintWhereConditions } from './complaints.util';
 import { BoardType, ComplaintStatus } from '@prisma/client';
@@ -298,7 +299,10 @@ export const patch = async (complaintId: string, data: ComplaintPatchDto) => {
  * @param data - 변경할 상태 (ComplaintStatus)
  * @returns 상태가 변경된 민원 상세 정보 (작성자, 댓글 목록 포함)
  */
-export const patchStatus = async (complaintId: string, data: ComplaintStatus) => {
+export const patchStatus = async (
+  complaintId: string,
+  data: ComplaintStatus,
+): Promise<ComplaintRawResponseDto> => {
   return await prisma.complaint.update({
     where: { id: complaintId },
     data: {

--- a/src/modules/complaints/dto/response.dto.ts
+++ b/src/modules/complaints/dto/response.dto.ts
@@ -44,3 +44,28 @@ export interface ComplaintListItemResponseDto {
   dong: string;
   ho: string;
 }
+
+// Prisma 결과 Raw 응답 DTO (repo 반환용)
+export interface ComplaintRawResponseDto {
+  id: string;
+  userId: string;
+  title: string;
+  status: ComplaintStatus;
+  isPublic: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  viewsCount: number;
+  content: string;
+  _count: { comments: number };
+  user: {
+    name: string;
+    resident: { building: string; unitNumber: string } | null;
+  };
+  comments: Array<{
+    id: string;
+    content: string;
+    createdAt: Date;
+    updatedAt: Date;
+    user: { id: string; name: string };
+  }>;
+}


### PR DESCRIPTION
## Summary

- `patchStatus` 함수의 TypeScript 타입 추론 오류 해결
- `ComplaintRawResponseDto` 타입을 `response.dto.ts`에 분리하여 관리

## Changed Files
- `src/modules/complaints/complaints.repo.ts`
- `src/modules/complaints/dto/response.dto.ts`